### PR TITLE
Improve API

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -21,12 +21,14 @@ var listCmd = &cobra.Command{
 		}
 		defer reader.Close()
 
-		entries, listErr := nvc.ReadToc(reader)
+		archive, listErr := nvc.Parse(reader)
 		if listErr != nil {
 			fmt.Fprintln(os.Stderr, listErr)
 			os.Exit(1)
 		}
-		for _, entry := range entries {
+
+		for _, hash := range archive.EntryOrder {
+			entry, _ := archive.Entries[hash]
 			fmt.Println(entry)
 		}
 	},

--- a/nvc/nvc_test.go
+++ b/nvc/nvc_test.go
@@ -1,0 +1,43 @@
+package nvc
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+func makeTestNVC(file []byte) []byte {
+	entry := TocEntry{
+		Hash:      String2Hash("/path/to/file"),
+		Offset:    8 + 4 + 24, // Magic bytes + ToC entry count + single ToC entry
+		RawLength: uint32(len(file)),
+		Length:    uint32(len(file)),
+		Flags:     EntryFlagNoCompression,
+	}
+
+	nvcFile := bytes.NewBuffer([]byte(magic))
+	binary.Write(nvcFile, binary.LittleEndian, uint32(1))
+	binary.Write(nvcFile, binary.LittleEndian, entry)
+	nvcFile.Write(file)
+
+	return nvcFile.Bytes()
+}
+
+func TestReadUncompressedFile(t *testing.T) {
+	input := "Testing\n"
+
+	nvcFileBytes := bytes.NewReader(makeTestNVC([]byte(input)))
+	parsed, err := Parse(nvcFileBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parsedContents, err := parsed.File(parsed.EntryOrder[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if bytes.Compare(parsedContents, []byte(input)) != 0 {
+		t.Fatalf("Got %v, expected %v\n", parsedContents, input)
+	}
+}


### PR DESCRIPTION
This PR improves the nvc package's API by creating an `Archive` type. This type holds a map of hashes to Table of Contents entries, and provides a method by which the actual files can be accessed via their hash.